### PR TITLE
[190] get django secret key from env

### DIFF
--- a/enrolment-service/enrol/enrol/settings.py
+++ b/enrolment-service/enrol/enrol/settings.py
@@ -18,8 +18,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '9bqg!2qdxnpy#@&i7m5p3@3002drp-v^gbled@8oz%nc7jxb(^'
+# Secret key must be set in .env, or Django may not run at all
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', False) == 'True'

--- a/env.template
+++ b/env.template
@@ -10,6 +10,7 @@ DB_PORT=5432
 DJANGO_SUPER_USER=user_name
 DJANGO_SUPER_MAIL=user@xyz.org
 DJANGO_SUPER_PASS=password
+DJANGO_SECRET_KEY=secretsecretsecret
 
 ICGC_CLIENT_KEY=keykeykey
 ICGC_CLIENT_SECRET=secretsecretsecret


### PR DESCRIPTION
Seems the Django secret key has been exposed for a couple years. This change fixes that.