### PR TITLE
[182] handle project status cul-de-sacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,4 +170,7 @@ As mentioned before, Google API credentials must be created in order for the log
 
 ### Step 4 - Run
 
-At this point if you visit the front-end `http://localhost` you will see the login page, now ready to login and authorize DACO approved Gmail addresses as well as accepting internal logins using the Django admin login setup in the config
+At this point if you visit the front-end `http://localhost` you will see the login page, now ready to login and authorize DACO approved Gmail addresses as well as accepting internal logins using the Django admin login setup in the config.
+
+While developing, you are able to use 'python -m smtpd -n -c DebuggingServer localhost:1025' to mock an email server.
+This tool logs the email to terminal; useful to test and debug notifications, etc.

--- a/enrolment-service/enrol/core/views.py
+++ b/enrolment-service/enrol/core/views.py
@@ -197,7 +197,7 @@ class ProjectsViewSet(CreateListRetrieveUpdateViewSet):
         project_users.update(status=new_status)
 
         # Termination Request
-        if updated_project.status == 3:
+        if updated_project.status == 3:  # new status 3. Termination Requested
             project_user_list = list(project_users.values())
 
             email = {
@@ -216,10 +216,10 @@ class ProjectsViewSet(CreateListRetrieveUpdateViewSet):
             send_update_notification(email)
 
         # Termination Confirmation
-        elif updated_project.status == 4:
+        elif updated_project.status == 4:  # new status 4. Terminated
 
-            # confirming a request.
-            if previous_status == 3:
+            # when the termination was requested by the PI
+            if previous_status == 3:  # previous status 3. Termination Requested
                 email = {
                     'to': project.user.email,
                     'cc': RESOURCE_ADMIN_EMAIL,
@@ -233,7 +233,7 @@ class ProjectsViewSet(CreateListRetrieveUpdateViewSet):
                 }
                 send_update_notification(email)
 
-            # force terminated
+            # when an admin terminates without a PI's request
             else:
                 logger.debug('project forcefully terminated by admin')
 

--- a/enrolment-service/enrol/core/views.py
+++ b/enrolment-service/enrol/core/views.py
@@ -193,11 +193,6 @@ class ProjectsViewSet(CreateListRetrieveUpdateViewSet):
         new_status = serializer.validated_data['status']
         # project_before = serializer.instance
 
-        logger.debug('updating id %s', project.id)
-        logger.debug('updating previous status %s', project.status)
-        logger.debug('updating incoming %s', serializer.validated_data)
-        logger.debug('updating by user %s', user)
-
         # Save the data
         updated_project = serializer.save()
         project_users = ProjectUsers.objects.filter(project=project.id)

--- a/enrolment-service/enrol/core/views.py
+++ b/enrolment-service/enrol/core/views.py
@@ -1,5 +1,3 @@
-# For email dev testing, use 'python -m smtpd -n -c DebuggingServer localhost:1025'
-
 import os
 import logging
 from core.models import Applications, Projects, ProjectUsers

--- a/enrolment-service/enrol/enrol/urls.py
+++ b/enrolment-service/enrol/enrol/urls.py
@@ -26,7 +26,7 @@ router.register(r'applications', views.ApplicationsViewSet, 'applications')
 projects_router = routers.NestedSimpleRouter(
     router, r'projects', lookup='project')
 projects_router.register(
-    r'users', views.ProjectUsersViewSet, base_name='project-users')
+    r'users', views.ProjectUsersViewSet, basename='project-users')
 
 urlpatterns = [
     url(r'^$', views.schema_view),

--- a/enrolment-service/enrol/package.json
+++ b/enrolment-service/enrol/package.json
@@ -17,6 +17,7 @@
         "ini": "^1.3.8",
         "kind-of": "^6.0.3",
         "mixin-deep": "^2.0.1",
-        "set-value": "^3.0.2"
+        "set-value": "^3.0.2",
+        "yargs-parser": "^20.2.4"
     }
 }

--- a/enrolment-service/enrol/yarn.lock
+++ b/enrolment-service/enrol/yarn.lock
@@ -1348,7 +1348,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4, object.assign@^4.1.0:
+object.assign@^4.0.4:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -1738,7 +1738,7 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.1:
+set-value@^0.4.3, set-value@^2.0.0, set-value@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
   integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
@@ -2163,13 +2163,10 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
-yargs-parser@5.0.0-security.0:
-  version "5.0.0-security.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz#4ff7271d25f90ac15643b86076a2ab499ec9ee24"
-  integrity sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==
-  dependencies:
-    camelcase "^3.0.0"
-    object.assign "^4.1.0"
+yargs-parser@5.0.0-security.0, yargs-parser@^20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs@^7.1.0:
   version "7.1.1"

--- a/enrolment-service/requirements.txt
+++ b/enrolment-service/requirements.txt
@@ -9,7 +9,7 @@ django-cors-headers==2.1.0
 django-nose==1.4.5
 django-rest-auth==0.9.1
 django-rest-swagger==2.1.0
-djangorestframework==3.9.1
+djangorestframework==3.11.2
 djangorestframework-bulk==0.2.1
 drf-nested-routers==0.92.5
 gunicorn==19.7.1

--- a/enrolment-ui/package.json
+++ b/enrolment-ui/package.json
@@ -22,7 +22,8 @@
     "redux": "^4.0.5",
     "redux-form": "^8.3.7",
     "redux-sessionstorage": "^0.4.0",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "web-vitals": "^1.1.0"
   },
   "proxy": "http://localhost:8000/",
   "scripts": {

--- a/enrolment-ui/public/locales/en/translation.json
+++ b/enrolment-ui/public/locales/en/translation.json
@@ -44,13 +44,16 @@
         "action": {
             "acceptInvite": "Accept",
             "approve": "Approve",
-            "confirmTermination": "Confirm Termination",
+            "confirmTermination": "Confirm",
             "deny": "Deny",
             "none": "No Action Needed",
             "pending": "Under Review",
             "purge": "Purge",
+            "rejectTermination": "Reject",
+            "reopen": "Reopen",
             "resendInvite": "Reinvite",
-            "terminate": "Terminate Project"
+            "reassess": "Reconsider",
+            "terminate": "Terminate"
         }
     },
     "FeesSidebarWidget":

--- a/enrolment-ui/public/locales/fr/translation.json
+++ b/enrolment-ui/public/locales/fr/translation.json
@@ -44,13 +44,16 @@
         "action": {
             "acceptInvite": "Admettre",
             "approve": "Approuver",
-            "confirmTermination": "Confirmer la résiliation",
-            "deny": "Nier",
+            "confirmTermination": "Confirmer",
+            "deny": "Refuser",
             "none": "Aucune action nécessaire",
             "pending": "En cours de révision",
             "purge": "Effacer",
-            "resendInvite": "réinviter",
-            "terminate": "Résilier le projet"
+            "rejectTermination": "Refuser",
+            "reopen": "Reprendre",
+            "resendInvite": "Réinviter",
+            "reassess": "Réexaminer",
+            "terminate": "Résilier"
         }
     },
     "FeesSidebarWidget":

--- a/enrolment-ui/src/index.js
+++ b/enrolment-ui/src/index.js
@@ -5,6 +5,7 @@ import { BrowserRouter, Switch } from 'react-router-dom';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 
+import reportWebVitals from './reportWebVitals';
 import { unregister } from './registerServiceWorker';
 import configureStore from './redux/store';
 
@@ -63,3 +64,8 @@ render(
   </Provider>,
   document.getElementById('root'),
 );
+
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals(localStorage.DEBUG && console.log);

--- a/enrolment-ui/src/modules/Projects/Projects.js
+++ b/enrolment-ui/src/modules/Projects/Projects.js
@@ -14,7 +14,7 @@ import {
   uiSelectProject,
   uiSelectTab,
   toggleProjectTerminationModal,
-} from '../Projects/redux';
+} from './redux';
 import { fetchProjectUsersByProjectId, clearProjectUsers } from '../ProjectUsers/redux';
 import { resetEnrolmentForm } from '../ProjectUsers/redux';
 

--- a/enrolment-ui/src/reportWebVitals.js
+++ b/enrolment-ui/src/reportWebVitals.js
@@ -1,0 +1,13 @@
+const reportWebVitals = onPerfEntry => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals;

--- a/enrolment-ui/yarn.lock
+++ b/enrolment-ui/yarn.lock
@@ -12105,6 +12105,11 @@ wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+web-vitals@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.0.tgz#7f410d9a1f7a1cd5d952806b45776204b47dc274"
+  integrity sha512-1cx54eRxY/+M0KNKdNpNnuXAXG+vJEvwScV4DiV9rOYDguHoeDIzm09ghBohOPtkqPO5OtPC14FWkNva3SDisg==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"


### PR DESCRIPTION
As per the ticket, this commit enables admins to revert project states that were basically "dead ends".
i.e. they can now "re-open" and "un-deny" projects, etc.